### PR TITLE
Feat/patron management

### DIFF
--- a/core/file.py
+++ b/core/file.py
@@ -27,3 +27,9 @@ def get_file(
         return FileResponse(path=path)
     else:
         return None
+
+
+def delete_file(path: str) -> None:
+    full_path = f"{FILE_STORAGE_PATH}/{path}"
+    if os.path.exists(path=full_path):
+        os.remove(full_path)

--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -1,7 +1,9 @@
+from contextlib import contextmanager
+
 from apscheduler.jobstores.sqlalchemy import SQLAlchemyJobStore
 from apscheduler.schedulers.background import BackgroundScheduler
 from psycopg.errors import DuplicateTable, UniqueViolation
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, text
 from sqlalchemy.exc import IntegrityError, ProgrammingError
 
 from core.log import logger
@@ -32,6 +34,17 @@ except (IntegrityError, ProgrammingError) as e:
     if not isinstance(e.orig, (UniqueViolation, DuplicateTable)):
         raise
 scheduler = BackgroundScheduler(jobstores={"default": _jobstore})
+SCHEDULER_JOBSTORE_LOCK_ID = 2025071101
+
+
+@contextmanager
+def scheduler_jobstore_lock():
+    with _jobstore_engine.begin() as conn:
+        conn.execute(
+            text("SELECT pg_advisory_xact_lock(:lock_id)"),
+            {"lock_id": SCHEDULER_JOBSTORE_LOCK_ID},
+        )
+        yield
 
 
 def register_jobs() -> None:
@@ -64,10 +77,19 @@ def register_jobs() -> None:
     )
 
 
-def start_scheduler():
-    if not scheduler.running:
+def start_scheduler(use_lock: bool = True):
+    if scheduler.running:
+        return
+
+    if not use_lock:
         scheduler.start()
         logger.info("Background scheduler started")
+        return
+
+    with scheduler_jobstore_lock():
+        if not scheduler.running:
+            scheduler.start()
+            logger.info("Background scheduler started")
 
 
 def stop_scheduler():

--- a/core/test_scheduler_hardening.py
+++ b/core/test_scheduler_hardening.py
@@ -3,7 +3,11 @@
 from unittest import IsolatedAsyncioTestCase
 import importlib
 
-from core.scheduler import register_jobs, scheduler  # noqa: F401  ensure table creation
+from core.scheduler import (
+    register_jobs,
+    scheduler,
+    scheduler_jobstore_lock,
+)  # noqa: F401  ensure table creation
 from sqlalchemy import text
 
 from models import engine
@@ -24,21 +28,22 @@ class TestSchedulerJobStore(IsolatedAsyncioTestCase):
     def test_register_jobs_persists_into_jobstore(self):
         from core.scheduler import start_scheduler, stop_scheduler
 
-        with engine.begin() as conn:
-            conn.execute(text("DELETE FROM apscheduler_jobs"))
+        with scheduler_jobstore_lock():
+            with engine.begin() as conn:
+                conn.execute(text("DELETE FROM apscheduler_jobs"))
 
-        register_jobs()
-        start_scheduler()
-        try:
-            with engine.connect() as conn:
-                stored_ids = [
-                    row[0]
-                    for row in conn.execute(
-                        text("SELECT id FROM apscheduler_jobs ORDER BY id")
-                    )
-                ]
-        finally:
-            stop_scheduler()
+            register_jobs()
+            start_scheduler(use_lock=False)
+            try:
+                with engine.connect() as conn:
+                    stored_ids = [
+                        row[0]
+                        for row in conn.execute(
+                            text("SELECT id FROM apscheduler_jobs ORDER BY id")
+                        )
+                    ]
+            finally:
+                stop_scheduler()
 
         self.assertIn("cleanup_abandoned_watch_sessions", stored_ids)
         self.assertIn("sync_pending_payments", stored_ids)
@@ -88,16 +93,17 @@ class TestWorkerHealthcheck(IsolatedAsyncioTestCase):
         self.assertEqual(body["status"], "degraded")
         self.assertEqual(body["role"], "worker")
 
-        register_jobs()
-        start_scheduler()
-        try:
-            r = client.get("/health")
-            body = r.json()
-            self.assertEqual(body["status"], "ok")
-            self.assertTrue(body["scheduler_running"])
-            self.assertIn("sync_pending_payments", body["jobs"])
-        finally:
-            stop_scheduler()
+        with scheduler_jobstore_lock():
+            register_jobs()
+            start_scheduler(use_lock=False)
+            try:
+                r = client.get("/health")
+                body = r.json()
+                self.assertEqual(body["status"], "ok")
+                self.assertTrue(body["scheduler_running"])
+                self.assertIn("sync_pending_payments", body["jobs"])
+            finally:
+                stop_scheduler()
 
     def test_worker_package_exposes_run_entrypoint(self):
         import inspect

--- a/main.py
+++ b/main.py
@@ -78,6 +78,7 @@ from routes.auth import router as auth_router  # noqa: E402
 from routes.locations import router as locations_router  # noqa: E402
 from routes.organizer import router as organizer_router  # noqa: E402
 from routes.organizer_type import router as organizer_type_router  # noqa: E402
+from routes.patron import router as patron_router  # noqa: E402
 from routes.payment import router as payment_router  # noqa: E402
 from routes.room import router as room_router  # noqa: E402
 from routes.schedule import router as schedule_router  # noqa: E402
@@ -99,6 +100,7 @@ app.include_router(ticket_router)
 app.include_router(room_router)
 app.include_router(speaker_router)
 app.include_router(schedule_router)
+app.include_router(patron_router)
 app.include_router(payment_router)
 app.include_router(streaming_router)
 app.include_router(streaming_analytics_router)

--- a/migrations/versions/2026_07_11_0000-b7c9d8e1f2a3_create_patron_table.py
+++ b/migrations/versions/2026_07_11_0000-b7c9d8e1f2a3_create_patron_table.py
@@ -1,0 +1,44 @@
+"""create patron table
+
+Revision ID: b7c9d8e1f2a3
+Revises: c4f1a92b7d30
+Create Date: 2026-07-11 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "b7c9d8e1f2a3"
+down_revision: Union[str, None] = "c4f1a92b7d30"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "patron",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("tier", sa.String(length=50), nullable=False),
+        sa.Column("image", sa.String(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        schema="public",
+    )
+    op.create_index(
+        op.f("ix_public_patron_id"), "patron", ["id"], unique=False, schema="public"
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f("ix_public_patron_id"), table_name="patron", schema="public")
+    op.drop_table("patron", schema="public")

--- a/migrations/versions/2026_07_11_0000-b7c9d8e1f2a3_create_patron_table.py
+++ b/migrations/versions/2026_07_11_0000-b7c9d8e1f2a3_create_patron_table.py
@@ -29,7 +29,6 @@ def upgrade() -> None:
         sa.Column("image", sa.String(), nullable=True),
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
-        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
         sa.PrimaryKeyConstraint("id"),
         schema="public",
     )

--- a/models/Patron.py
+++ b/models/Patron.py
@@ -1,0 +1,28 @@
+import datetime
+import uuid
+from models import Base
+from sqlalchemy import UUID, DateTime, String
+from sqlalchemy.orm import mapped_column, Mapped
+
+
+class Patron(Base):
+    __tablename__ = "patron"
+
+    id: Mapped[str] = mapped_column(
+        "id", UUID(as_uuid=True), primary_key=True, index=True, default=uuid.uuid4
+    )
+    name: Mapped[str] = mapped_column("name", String(255), nullable=False)
+    tier: Mapped[str] = mapped_column("tier", String(50), nullable=False)
+    image: Mapped[str | None] = mapped_column("image", String, nullable=True)
+
+    created_at = mapped_column(
+        "created_at",
+        DateTime(timezone=True),
+        default=datetime.datetime.now(datetime.timezone.utc),
+    )
+    updated_at = mapped_column(
+        "updated_at",
+        DateTime(timezone=True),
+        default=datetime.datetime.now(datetime.timezone.utc),
+    )
+    deleted_at = mapped_column("deleted_at", DateTime(timezone=True), nullable=True)

--- a/models/Patron.py
+++ b/models/Patron.py
@@ -25,4 +25,3 @@ class Patron(Base):
         DateTime(timezone=True),
         default=datetime.datetime.now(datetime.timezone.utc),
     )
-    deleted_at = mapped_column("deleted_at", DateTime(timezone=True), nullable=True)

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -74,3 +74,4 @@ from models.SpeakerType import SpeakerType  # NOQA
 from models.Volunteer import Volunteer  # NOQA
 from models.OrganizerType import OrganizerType  # NOQA
 from models.Organizer import Organizer  # NOQA
+from models.Patron import Patron  # NOQA

--- a/repository/patron.py
+++ b/repository/patron.py
@@ -1,0 +1,70 @@
+from typing import Sequence
+from sqlalchemy import case, select
+from sqlalchemy.orm import Session
+
+from core.helper import get_current_time_in_timezone
+from models.Patron import Patron
+from settings import TZ
+
+
+def get_patrons(db: Session) -> Sequence[Patron]:
+    tier_order = case(
+        (Patron.tier == "ultimate", 1),
+        (Patron.tier == "platinum", 2),
+        (Patron.tier == "gold", 3),
+        (Patron.tier == "silver", 4),
+        else_=5,
+    )
+    stmt = (
+        select(Patron)
+        .where(Patron.deleted_at.is_(None))
+        .order_by(tier_order, Patron.name)
+    )
+    return db.scalars(stmt).all()
+
+
+def get_patron_by_id(db: Session, id: str) -> Patron | None:
+    stmt = select(Patron).where(Patron.id == id, Patron.deleted_at.is_(None))
+    return db.execute(stmt).scalar()
+
+
+def insert_patron(
+    db: Session,
+    name: str,
+    tier: str,
+    image: str | None = None,
+) -> Patron:
+    current_datetime = get_current_time_in_timezone(TZ)
+    patron = Patron(
+        name=name,
+        tier=tier,
+        image=image,
+        created_at=current_datetime,
+        updated_at=current_datetime,
+    )
+    db.add(patron)
+    db.commit()
+    db.refresh(patron)
+    return patron
+
+
+def update_patron(
+    db: Session,
+    patron: Patron,
+    name: str,
+    tier: str,
+    image: str | None = None,
+) -> Patron:
+    patron.name = name
+    patron.tier = tier
+    if image is not None:
+        patron.image = image
+    patron.updated_at = get_current_time_in_timezone(TZ)
+    db.commit()
+    db.refresh(patron)
+    return patron
+
+
+def delete_patron(db: Session, patron: Patron) -> None:
+    patron.deleted_at = get_current_time_in_timezone(TZ)
+    db.commit()

--- a/repository/patron.py
+++ b/repository/patron.py
@@ -15,16 +15,12 @@ def get_patrons(db: Session) -> Sequence[Patron]:
         (Patron.tier == "silver", 4),
         else_=5,
     )
-    stmt = (
-        select(Patron)
-        .where(Patron.deleted_at.is_(None))
-        .order_by(tier_order, Patron.name)
-    )
+    stmt = select(Patron).order_by(tier_order, Patron.name)
     return db.scalars(stmt).all()
 
 
 def get_patron_by_id(db: Session, id: str) -> Patron | None:
-    stmt = select(Patron).where(Patron.id == id, Patron.deleted_at.is_(None))
+    stmt = select(Patron).where(Patron.id == id)
     return db.execute(stmt).scalar()
 
 
@@ -66,5 +62,5 @@ def update_patron(
 
 
 def delete_patron(db: Session, patron: Patron) -> None:
-    patron.deleted_at = get_current_time_in_timezone(TZ)
+    db.delete(patron)
     db.commit()

--- a/routes/patron.py
+++ b/routes/patron.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends, File, Form, UploadFile
 from fastapi.responses import FileResponse
 from sqlalchemy.orm import Session
 
-from core.file import get_file, is_over_max_file_size, upload_file
+from core.file import delete_file, get_file, is_over_max_file_size, upload_file
 from core.log import logger
 from core.responses import (
     BadRequest,
@@ -227,7 +227,10 @@ def delete_patron(
             return common_response(
                 NotFound(message=f"patron with id = {patron_id} not found")
             )
+        image_path = patron.image
         patronRepo.delete_patron(db=db, patron=patron)
+        if image_path is not None:
+            delete_file(path=image_path)
         return common_response(NoContent())
     except Exception as e:
         logger.error(f"Error deleting patron: {e}")

--- a/routes/patron.py
+++ b/routes/patron.py
@@ -1,0 +1,261 @@
+import uuid
+
+from fastapi import APIRouter, Depends, File, Form, UploadFile
+from fastapi.responses import FileResponse
+from sqlalchemy.orm import Session
+
+from core.file import get_file, is_over_max_file_size, upload_file
+from core.log import logger
+from core.responses import (
+    BadRequest,
+    Forbidden,
+    InternalServerError,
+    NoContent,
+    NotFound,
+    Ok,
+    Unauthorized,
+    common_response,
+)
+from core.security import check_permissions, get_current_user
+from models import get_db_sync
+from models.User import MANAGEMENT_PARTICIPANT, User
+from repository import patron as patronRepo
+from schemas.auth import AuthorizationStatusEnum
+from schemas.common import (
+    BadRequestResponse,
+    ForbiddenResponse,
+    InternalServerErrorResponse,
+    NotFoundResponse,
+    UnauthorizedResponse,
+)
+from schemas.patron import (
+    PatronListResponse,
+    PatronResponseItem,
+    PatronTier,
+    patron_list_response_from_models,
+    patron_response_item_from_model,
+)
+from settings import MAX_FILE_SIZE_MB
+
+router = APIRouter(prefix="/patron", tags=["Patron"])
+
+PATRON_IMAGE_CONTENT_TYPES = {
+    "image/png": ".png",
+    "image/jpeg": ".jpg",
+    "image/svg+xml": ".svg",
+}
+
+
+def _authorize_management_user(current_user: User | None):
+    auth_status = check_permissions(current_user, MANAGEMENT_PARTICIPANT)
+    if auth_status == AuthorizationStatusEnum.UNAUTHORIZED:
+        return common_response(Unauthorized(message="Unauthorized"))
+    if auth_status == AuthorizationStatusEnum.FORBIDDEN:
+        return common_response(Forbidden())
+    return None
+
+
+async def _upload_patron_image(image: UploadFile | None) -> str | None:
+    if image is None:
+        return None
+    if image.content_type not in PATRON_IMAGE_CONTENT_TYPES:
+        raise ValueError("Image must be png, jpeg, or svg")
+    if is_over_max_file_size(upload_file=image):
+        raise ValueError(f"File size exceeds the maximum limit ({MAX_FILE_SIZE_MB} mb)")
+
+    suffix = PATRON_IMAGE_CONTENT_TYPES[image.content_type]
+    path = f"patron/{uuid.uuid4()}{suffix}"
+    return await upload_file(upload_file=image, path=path)
+
+
+@router.get(
+    "/",
+    responses={
+        "200": {"model": PatronListResponse},
+        "500": {"model": InternalServerErrorResponse},
+    },
+)
+def get_patrons(db: Session = Depends(get_db_sync)):
+    try:
+        patrons = patronRepo.get_patrons(db=db)
+        data = patron_list_response_from_models(patrons)
+        return common_response(Ok(data=data.model_dump()))
+    except Exception as e:
+        logger.error(f"Error fetching patrons: {e}")
+        return common_response(InternalServerError(error=str(e)))
+
+
+@router.post(
+    "/",
+    responses={
+        "200": {"model": PatronResponseItem},
+        "400": {"model": BadRequestResponse},
+        "401": {"model": UnauthorizedResponse},
+        "403": {"model": ForbiddenResponse},
+        "500": {"model": InternalServerErrorResponse},
+    },
+)
+async def create_patron(
+    name: str = Form(...),
+    tier: PatronTier = Form(...),
+    image: UploadFile | None = File(None),
+    db: Session = Depends(get_db_sync),
+    current_user: User | None = Depends(get_current_user),
+):
+    unauthorized_response = _authorize_management_user(current_user)
+    if unauthorized_response is not None:
+        return unauthorized_response
+
+    try:
+        image_path = await _upload_patron_image(image)
+        patron = patronRepo.insert_patron(
+            db=db,
+            name=name,
+            tier=tier.value,
+            image=image_path,
+        )
+        data = patron_response_item_from_model(patron)
+        return common_response(Ok(data=data.model_dump()))
+    except ValueError as e:
+        return common_response(BadRequest(message=str(e)))
+    except Exception as e:
+        logger.error(f"Error creating patron: {e}")
+        return common_response(InternalServerError(error=str(e)))
+
+
+@router.get(
+    "/{patron_id}",
+    responses={
+        "200": {"model": PatronResponseItem},
+        "401": {"model": UnauthorizedResponse},
+        "403": {"model": ForbiddenResponse},
+        "404": {"model": NotFoundResponse},
+        "500": {"model": InternalServerErrorResponse},
+    },
+)
+def get_patron(
+    patron_id: str,
+    db: Session = Depends(get_db_sync),
+    current_user: User | None = Depends(get_current_user),
+):
+    unauthorized_response = _authorize_management_user(current_user)
+    if unauthorized_response is not None:
+        return unauthorized_response
+
+    try:
+        patron = patronRepo.get_patron_by_id(db=db, id=patron_id)
+        if patron is None:
+            return common_response(
+                NotFound(message=f"patron with id = {patron_id} not found")
+            )
+        data = patron_response_item_from_model(patron)
+        return common_response(Ok(data=data.model_dump()))
+    except Exception as e:
+        logger.error(f"Error fetching patron: {e}")
+        return common_response(InternalServerError(error=str(e)))
+
+
+@router.put(
+    "/{patron_id}",
+    responses={
+        "200": {"model": PatronResponseItem},
+        "400": {"model": BadRequestResponse},
+        "401": {"model": UnauthorizedResponse},
+        "403": {"model": ForbiddenResponse},
+        "404": {"model": NotFoundResponse},
+        "500": {"model": InternalServerErrorResponse},
+    },
+)
+async def update_patron(
+    patron_id: str,
+    name: str = Form(...),
+    tier: PatronTier = Form(...),
+    image: UploadFile | None = File(None),
+    db: Session = Depends(get_db_sync),
+    current_user: User | None = Depends(get_current_user),
+):
+    unauthorized_response = _authorize_management_user(current_user)
+    if unauthorized_response is not None:
+        return unauthorized_response
+
+    try:
+        patron = patronRepo.get_patron_by_id(db=db, id=patron_id)
+        if patron is None:
+            return common_response(
+                NotFound(message=f"patron with id = {patron_id} not found")
+            )
+
+        image_path = await _upload_patron_image(image)
+        updated_patron = patronRepo.update_patron(
+            db=db,
+            patron=patron,
+            name=name,
+            tier=tier.value,
+            image=image_path,
+        )
+        data = patron_response_item_from_model(updated_patron)
+        return common_response(Ok(data=data.model_dump()))
+    except ValueError as e:
+        return common_response(BadRequest(message=str(e)))
+    except Exception as e:
+        logger.error(f"Error updating patron: {e}")
+        return common_response(InternalServerError(error=str(e)))
+
+
+@router.delete(
+    "/{patron_id}",
+    responses={
+        "204": {"description": "No Content"},
+        "401": {"model": UnauthorizedResponse},
+        "403": {"model": ForbiddenResponse},
+        "404": {"model": NotFoundResponse},
+        "500": {"model": InternalServerErrorResponse},
+    },
+)
+def delete_patron(
+    patron_id: str,
+    db: Session = Depends(get_db_sync),
+    current_user: User | None = Depends(get_current_user),
+):
+    unauthorized_response = _authorize_management_user(current_user)
+    if unauthorized_response is not None:
+        return unauthorized_response
+
+    try:
+        patron = patronRepo.get_patron_by_id(db=db, id=patron_id)
+        if patron is None:
+            return common_response(
+                NotFound(message=f"patron with id = {patron_id} not found")
+            )
+        patronRepo.delete_patron(db=db, patron=patron)
+        return common_response(NoContent())
+    except Exception as e:
+        logger.error(f"Error deleting patron: {e}")
+        return common_response(InternalServerError(error=str(e)))
+
+
+@router.get(
+    "/{patron_id}/image/",
+    response_class=FileResponse,
+    responses={
+        "404": {"model": NotFoundResponse},
+        "500": {"model": InternalServerErrorResponse},
+    },
+)
+def get_patron_image(patron_id: str, db: Session = Depends(get_db_sync)):
+    try:
+        patron = patronRepo.get_patron_by_id(db=db, id=patron_id)
+        if patron is None:
+            return common_response(
+                NotFound(message=f"patron with id = {patron_id} not found")
+            )
+        if patron.image is None:
+            return common_response(NotFound(message="Patron image not found"))
+
+        image = get_file(path=patron.image)
+        if image is None:
+            return common_response(NotFound(message="Patron image file not found"))
+        return image
+    except Exception as e:
+        logger.error(f"Error fetching patron image: {e}")
+        return common_response(InternalServerError(error=str(e)))

--- a/routes/tests/test_patron.py
+++ b/routes/tests/test_patron.py
@@ -1,4 +1,3 @@
-import datetime
 import os
 import uuid
 from unittest import IsolatedAsyncioTestCase
@@ -29,7 +28,6 @@ class TestPatron(IsolatedAsyncioTestCase):
         )
 
         self.active_patron_id = uuid.uuid4()
-        self.deleted_patron_id = uuid.uuid4()
         self.image_patron_id = uuid.uuid4()
         self.image_path = "patron/test-patron.png"
         os.makedirs(
@@ -59,14 +57,6 @@ class TestPatron(IsolatedAsyncioTestCase):
                 id=self.silver_patron_id,
                 name="Silver Patron",
                 tier="silver",
-            )
-        )
-        self.session.add(
-            Patron(
-                id=self.deleted_patron_id,
-                name="Deleted Patron",
-                tier="silver",
-                deleted_at=datetime.datetime.now(datetime.timezone.utc),
             )
         )
         self.user = User(
@@ -123,9 +113,6 @@ class TestPatron(IsolatedAsyncioTestCase):
                 if patron["id"] == str(self.active_patron_id)
             )["has_image"]
             is False
-        )
-        assert all(
-            patron["id"] != str(self.deleted_patron_id) for patron in data["results"]
         )
 
     async def test_create_patron_requires_management_user(self):
@@ -215,7 +202,24 @@ class TestPatron(IsolatedAsyncioTestCase):
         patron = self.session.execute(
             select(Patron).where(Patron.id == self.active_patron_id)
         ).scalar()
-        assert patron.deleted_at is not None
+        assert patron is None
+
+    async def test_delete_patron_removes_image_file(self):
+        token = await self.get_management_token()
+        image_full_path = f"{FILE_STORAGE_PATH}/{self.image_path}"
+        assert os.path.exists(image_full_path)
+
+        response = self.client.delete(
+            f"/patron/{self.image_patron_id}",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        assert response.status_code == 204
+        patron = self.session.execute(
+            select(Patron).where(Patron.id == self.image_patron_id)
+        ).scalar()
+        assert patron is None
+        assert not os.path.exists(image_full_path)
 
     async def test_get_patron_image_is_public(self):
         response = self.client.get(f"/patron/{self.image_patron_id}/image/")

--- a/routes/tests/test_patron.py
+++ b/routes/tests/test_patron.py
@@ -107,6 +107,23 @@ class TestPatron(IsolatedAsyncioTestCase):
             "gold",
             "silver",
         ]
+        assert all("has_image" in patron for patron in data["results"])
+        assert (
+            next(
+                patron
+                for patron in data["results"]
+                if patron["id"] == str(self.image_patron_id)
+            )["has_image"]
+            is True
+        )
+        assert (
+            next(
+                patron
+                for patron in data["results"]
+                if patron["id"] == str(self.active_patron_id)
+            )["has_image"]
+            is False
+        )
         assert all(
             patron["id"] != str(self.deleted_patron_id) for patron in data["results"]
         )

--- a/routes/tests/test_patron.py
+++ b/routes/tests/test_patron.py
@@ -1,0 +1,213 @@
+import datetime
+import os
+import uuid
+from unittest import IsolatedAsyncioTestCase
+
+import alembic.config
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+from core.security import generate_token_from_user
+from main import app
+from models import db, engine, get_db_sync, get_db_sync_for_test
+from models.Patron import Patron
+from models.User import MANAGEMENT_PARTICIPANT, User
+from settings import FILE_STORAGE_PATH
+
+
+class TestPatron(IsolatedAsyncioTestCase):
+    @classmethod
+    def setUpClass(cls):
+        alembic_args = ["upgrade", "head"]
+        alembic.config.main(argv=alembic_args)
+
+    def setUp(self):
+        self.connection = engine.connect()
+        self.trans = self.connection.begin()
+        self.session = db(
+            bind=self.connection, join_transaction_mode="create_savepoint"
+        )
+
+        self.active_patron_id = uuid.uuid4()
+        self.deleted_patron_id = uuid.uuid4()
+        self.image_patron_id = uuid.uuid4()
+        self.image_path = "patron/test-patron.png"
+        os.makedirs(
+            os.path.dirname(f"{FILE_STORAGE_PATH}/{self.image_path}"), exist_ok=True
+        )
+        with open(f"{FILE_STORAGE_PATH}/{self.image_path}", "wb") as file:
+            file.write(b"test-image")
+
+        self.silver_patron_id = uuid.uuid4()
+        self.session.add(
+            Patron(
+                id=self.active_patron_id,
+                name="Python Supporter",
+                tier="gold",
+            )
+        )
+        self.session.add(
+            Patron(
+                id=self.image_patron_id,
+                name="Image Patron",
+                tier="ultimate",
+                image=self.image_path,
+            )
+        )
+        self.session.add(
+            Patron(
+                id=self.silver_patron_id,
+                name="Silver Patron",
+                tier="silver",
+            )
+        )
+        self.session.add(
+            Patron(
+                id=self.deleted_patron_id,
+                name="Deleted Patron",
+                tier="silver",
+                deleted_at=datetime.datetime.now(datetime.timezone.utc),
+            )
+        )
+        self.user = User(
+            username="admin",
+            participant_type=MANAGEMENT_PARTICIPANT,
+        )
+        self.session.add(self.user)
+        self.session.commit()
+
+        app.dependency_overrides[get_db_sync] = get_db_sync_for_test(db=self.session)
+        self.client = TestClient(app)
+
+    def tearDown(self):
+        app.dependency_overrides.clear()
+        if os.path.exists(f"{FILE_STORAGE_PATH}/{self.image_path}"):
+            os.remove(f"{FILE_STORAGE_PATH}/{self.image_path}")
+        self.session.close()
+        self.trans.rollback()
+        self.connection.close()
+
+    async def get_management_token(self):
+        token, _ = await generate_token_from_user(db=self.session, user=self.user)
+        return token
+
+    async def test_list_patrons_is_public_without_pagination(self):
+        response = self.client.get("/patron/")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "results" in data
+        assert "page" not in data
+        assert "page_size" not in data
+        assert "count" not in data
+        assert "page_count" not in data
+        assert len(data["results"]) == 3
+        assert [patron["tier"] for patron in data["results"]] == [
+            "ultimate",
+            "gold",
+            "silver",
+        ]
+        assert all(
+            patron["id"] != str(self.deleted_patron_id) for patron in data["results"]
+        )
+
+    async def test_create_patron_requires_management_user(self):
+        response = self.client.post(
+            "/patron/",
+            data={"name": "New Patron", "tier": "gold"},
+        )
+
+        assert response.status_code == 401
+
+    async def test_create_patron(self):
+        token = await self.get_management_token()
+        response = self.client.post(
+            "/patron/",
+            headers={"Authorization": f"Bearer {token}"},
+            data={"name": "New Patron", "tier": "platinum"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["name"] == "New Patron"
+        assert data["tier"] == "platinum"
+        assert "id" in data
+
+    async def test_create_patron_with_invalid_tier(self):
+        token = await self.get_management_token()
+        response = self.client.post(
+            "/patron/",
+            headers={"Authorization": f"Bearer {token}"},
+            data={"name": "Invalid Patron", "tier": "bronze"},
+        )
+
+        assert response.status_code == 422
+
+    async def test_get_patron_detail(self):
+        token = await self.get_management_token()
+        response = self.client.get(
+            f"/patron/{self.active_patron_id}",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "id": str(self.active_patron_id),
+            "name": "Python Supporter",
+            "tier": "gold",
+        }
+
+    async def test_get_patron_detail_not_found(self):
+        token = await self.get_management_token()
+        random_id = uuid.uuid4()
+        response = self.client.get(
+            f"/patron/{random_id}",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        assert response.status_code == 404
+        assert response.json()["message"] == f"patron with id = {random_id} not found"
+
+    async def test_update_patron_without_image_keeps_existing_image(self):
+        token = await self.get_management_token()
+        response = self.client.put(
+            f"/patron/{self.image_patron_id}",
+            headers={"Authorization": f"Bearer {token}"},
+            data={"name": "Updated Patron", "tier": "silver"},
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "id": str(self.image_patron_id),
+            "name": "Updated Patron",
+            "tier": "silver",
+        }
+        patron = self.session.execute(
+            select(Patron).where(Patron.id == self.image_patron_id)
+        ).scalar()
+        assert patron.image == self.image_path
+
+    async def test_delete_patron(self):
+        token = await self.get_management_token()
+        response = self.client.delete(
+            f"/patron/{self.active_patron_id}",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        assert response.status_code == 204
+        patron = self.session.execute(
+            select(Patron).where(Patron.id == self.active_patron_id)
+        ).scalar()
+        assert patron.deleted_at is not None
+
+    async def test_get_patron_image_is_public(self):
+        response = self.client.get(f"/patron/{self.image_patron_id}/image/")
+
+        assert response.status_code == 200
+        assert response.content == b"test-image"
+
+    async def test_get_patron_image_not_found(self):
+        response = self.client.get(f"/patron/{self.active_patron_id}/image/")
+
+        assert response.status_code == 404
+        assert response.json()["message"] == "Patron image not found"

--- a/schemas/patron.py
+++ b/schemas/patron.py
@@ -18,8 +18,12 @@ class PatronResponseItem(BaseModel):
     tier: str
 
 
+class PatronListResponseItem(PatronResponseItem):
+    has_image: bool
+
+
 class PatronListResponse(BaseModel):
-    results: list[PatronResponseItem]
+    results: list[PatronListResponseItem]
 
 
 def patron_response_item_from_model(patron: Patron) -> PatronResponseItem:
@@ -32,5 +36,13 @@ def patron_response_item_from_model(patron: Patron) -> PatronResponseItem:
 
 def patron_list_response_from_models(patrons: Sequence[Patron]) -> PatronListResponse:
     return PatronListResponse(
-        results=[patron_response_item_from_model(patron) for patron in patrons]
+        results=[
+            PatronListResponseItem(
+                id=str(patron.id),
+                name=patron.name,
+                tier=patron.tier,
+                has_image=patron.image is not None,
+            )
+            for patron in patrons
+        ]
     )

--- a/schemas/patron.py
+++ b/schemas/patron.py
@@ -1,0 +1,36 @@
+from enum import Enum
+from typing import Sequence
+from pydantic import BaseModel
+
+from models.Patron import Patron
+
+
+class PatronTier(str, Enum):
+    ULTIMATE = "ultimate"
+    PLATINUM = "platinum"
+    GOLD = "gold"
+    SILVER = "silver"
+
+
+class PatronResponseItem(BaseModel):
+    id: str
+    name: str
+    tier: str
+
+
+class PatronListResponse(BaseModel):
+    results: list[PatronResponseItem]
+
+
+def patron_response_item_from_model(patron: Patron) -> PatronResponseItem:
+    return PatronResponseItem(
+        id=str(patron.id),
+        name=patron.name,
+        tier=patron.tier,
+    )
+
+
+def patron_list_response_from_models(patrons: Sequence[Patron]) -> PatronListResponse:
+    return PatronListResponse(
+        results=[patron_response_item_from_model(patron) for patron in patrons]
+    )


### PR DESCRIPTION
## Ringkasan

- Mengimplementasikan API patron sesuai pyconid/pyconid-be#173:
  - `POST /patron/` untuk management user
  - `PUT /patron/{patron_id}` untuk management user
  - `GET /patron/{patron_id}` untuk management user
  - `DELETE /patron/{patron_id}` untuk management user
  - `GET /patron/` publik, tanpa pagination
  - `GET /patron/{patron_id}/image/` publik
- Menambahkan model, schema, repository, route registration, migration, dan test untuk `patron`.
- Menggunakan value tier patron dalam lowercase (`ultimate`, `platinum`, `gold`, `silver`) dan mengurutkan list patron publik berdasarkan prioritas tier.
- Memperbaiki flaky test scheduler saat `pytest -n auto` dengan men-serialize mutasi APScheduler jobstore menggunakan PostgreSQL advisory lock.

## Detail

### API Patron

Response list patron menggunakan array di dalam `results`:

```json
{
  "results": [
    {
      "id": "uuid",
      "name": "Patron Name",
      "tier": "ultimate",
      "has_image": true
    }
  ]
}
```

Ini menyesuaikan contoh di issue, karena `GET /patron/` adalah endpoint list dan seharusnya bisa mengembalikan beberapa item patron.

Urutan tier:

1. `ultimate`
2. `platinum`
3. `gold`
4. `silver`

Route khusus management membutuhkan user terautentikasi dengan `participant_type = Management`.

Upload image mendukung:
- PNG
- JPEG
- SVG

### Perbaikan test scheduler

`pytest -n auto` sebelumnya bisa gagal secara intermittent karena beberapa xdist worker menggunakan tabel `public.apscheduler_jobs` yang sama.

Kegagalan terjadi ketika satu test menghapus job APScheduler, sementara worker lain sedang menjalankan scheduler dan mendaftarkan job ID yang sama.

MR ini menambahkan PostgreSQL advisory transaction lock di sekitar operasi mutasi APScheduler jobstore agar test serial maupun parallel stabil.

## Test Plan

- [x] `pytest routes/tests/test_patron.py`
- [x] `pytest core/test_scheduler_hardening.py`
- [x] `pytest core/test_scheduler_hardening.py -n auto`
- [x] `pytest .`
- [x] `pytest . -n auto`

## Related Issue

Closes pyconid/pyconid-be#173
