### PR TITLE
feat(voucher): restrict usage by ticket

### DIFF
--- a/migrations/versions/2026_07_25_0100-add_voucher_ticket_table.py
+++ b/migrations/versions/2026_07_25_0100-add_voucher_ticket_table.py
@@ -1,0 +1,52 @@
+"""add voucher ticket table
+
+Revision ID: 2f45e9d7a8c1
+Revises: b7c9d8e1f2a3
+Create Date: 2026-07-25 01:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "2f45e9d7a8c1"
+down_revision: Union[str, None] = "b7c9d8e1f2a3"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "voucher_ticket",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("voucher_id", sa.UUID(), nullable=False),
+        sa.Column("ticket_id", sa.UUID(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["ticket_id"], ["public.ticket.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["voucher_id"], ["public.voucher.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("voucher_id", "ticket_id"),
+        schema="public",
+    )
+    op.create_index(
+        op.f("ix_public_voucher_ticket_id"),
+        "voucher_ticket",
+        ["id"],
+        unique=False,
+        schema="public",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        op.f("ix_public_voucher_ticket_id"),
+        table_name="voucher_ticket",
+        schema="public",
+    )
+    op.drop_table("voucher_ticket", schema="public")

--- a/models/Ticket.py
+++ b/models/Ticket.py
@@ -1,7 +1,8 @@
 import uuid
 from sqlalchemy import UUID, String, Integer, Boolean
-from sqlalchemy.orm import mapped_column, Mapped
+from sqlalchemy.orm import mapped_column, Mapped, relationship
 from models import Base
+from models.VoucherTicket import VoucherTicket
 
 
 class Ticket(Base):
@@ -19,3 +20,6 @@ class Ticket(Base):
     is_active: Mapped[bool] = mapped_column("is_active", Boolean, default=True)
     description: Mapped[str] = mapped_column("description", String, nullable=True)
     order: Mapped[int] = mapped_column("order", Integer, nullable=True)
+    vouchers = relationship(
+        "Voucher", secondary=lambda: VoucherTicket.__table__, back_populates="tickets"
+    )

--- a/models/Voucher.py
+++ b/models/Voucher.py
@@ -1,8 +1,9 @@
 import uuid
 from sqlalchemy import UUID, String, Integer, Boolean
 from sqlalchemy.dialects.postgresql import JSONB
-from sqlalchemy.orm import mapped_column, Mapped
+from sqlalchemy.orm import mapped_column, Mapped, relationship
 from models import Base
+from models.VoucherTicket import VoucherTicket
 
 
 class Voucher(Base):
@@ -19,3 +20,6 @@ class Voucher(Base):
     )
     quota: Mapped[int] = mapped_column("quota", Integer, nullable=False)
     is_active: Mapped[bool] = mapped_column("is_active", Boolean, default=False)
+    tickets = relationship(
+        "Ticket", secondary=lambda: VoucherTicket.__table__, back_populates="vouchers"
+    )

--- a/models/VoucherTicket.py
+++ b/models/VoucherTicket.py
@@ -1,0 +1,27 @@
+import uuid
+
+from sqlalchemy import UUID, ForeignKey, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from models import Base
+
+
+class VoucherTicket(Base):
+    __tablename__ = "voucher_ticket"
+    __table_args__ = (UniqueConstraint("voucher_id", "ticket_id"),)
+
+    id: Mapped[str] = mapped_column(
+        "id", UUID(as_uuid=True), primary_key=True, index=True, default=uuid.uuid4
+    )
+    voucher_id: Mapped[str] = mapped_column(
+        "voucher_id",
+        UUID(as_uuid=True),
+        ForeignKey("voucher.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    ticket_id: Mapped[str] = mapped_column(
+        "ticket_id",
+        UUID(as_uuid=True),
+        ForeignKey("ticket.id", ondelete="CASCADE"),
+        nullable=False,
+    )

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -68,6 +68,7 @@ from models.Schedule import Schedule  # NOQA
 from models.Speaker import Speaker  # NOQA
 from models.SpeakerSchedule import SpeakerSchedule  # NOQA
 from models.Voucher import Voucher  # NOQA
+from models.VoucherTicket import VoucherTicket  # NOQA
 from models.Stream import Stream  # NOQA
 from models.StreamWatchSession import StreamWatchSession  # NOQA
 from models.SpeakerType import SpeakerType  # NOQA

--- a/repository/voucher.py
+++ b/repository/voucher.py
@@ -1,12 +1,15 @@
 from typing import Optional
 from sqlalchemy import select, func
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, selectinload
+from models.Ticket import Ticket
 from models.Voucher import Voucher
 from schemas.voucher import VoucherResponseItem
 
 
 def get_voucher_by_id(db: Session, id: str) -> Optional[Voucher]:
-    query = select(Voucher).where(Voucher.id == id)
+    query = (
+        select(Voucher).options(selectinload(Voucher.tickets)).where(Voucher.id == id)
+    )
     voucher = db.execute(query).scalar()
     return voucher
 
@@ -19,7 +22,9 @@ def insert_voucher(
     type: str | None = None,
     email_whitelist: dict | None = None,
     is_active: bool = False,
+    ticket_ids: list[str] | None = None,
 ) -> Voucher:
+    tickets = get_tickets_by_ids(db=db, ticket_ids=ticket_ids or [])
     voucher = Voucher(
         code=code,
         value=value,
@@ -27,6 +32,7 @@ def insert_voucher(
         type=type,
         email_whitelist=email_whitelist,
         is_active=is_active,
+        tickets=tickets,
     )
     db.add(voucher)
     db.commit()
@@ -43,14 +49,17 @@ def update_voucher(
     type: Optional[str] = None,
     email_whitelist: Optional[dict] = None,
     is_active: Optional[bool] = None,
+    ticket_ids: list[str] | None = None,
     is_commit: bool = True,
 ) -> Optional[Voucher]:
+    tickets = get_tickets_by_ids(db=db, ticket_ids=ticket_ids or [])
     voucher.code = code
     voucher.value = value
     voucher.quota = quota
     voucher.type = type
     voucher.email_whitelist = email_whitelist
     voucher.is_active = is_active
+    voucher.tickets = tickets
     if is_commit:
         db.commit()
     return voucher
@@ -146,7 +155,11 @@ def get_vouchers_per_page(
 
 
 def get_voucher_by_code(db: Session, code: str) -> Optional[Voucher]:
-    stmt = select(Voucher).where(func.upper(Voucher.code) == code.strip().upper())
+    stmt = (
+        select(Voucher)
+        .options(selectinload(Voucher.tickets))
+        .where(func.upper(Voucher.code) == code.strip().upper())
+    )
     voucher = db.execute(stmt).scalar()
     return voucher
 
@@ -155,10 +168,12 @@ def validate_and_use_voucher(
     db: Session,
     code: str,
     user_email: str,
+    ticket_id: str | None = None,
 ) -> tuple[Optional[Voucher], Optional[str]]:
     # Lock the voucher row for update to prevent race conditions
     stmt = (
         select(Voucher)
+        .options(selectinload(Voucher.tickets))
         .where(func.upper(Voucher.code) == code.strip().upper())
         .with_for_update()
     )
@@ -183,7 +198,29 @@ def validate_and_use_voucher(
         if whitelist_normalized and user_email_normalized not in whitelist_normalized:
             return None, "You are not authorized to use this voucher."
 
+    if not voucher_can_be_used_for_ticket(voucher=voucher, ticket_id=ticket_id):
+        return None, "Voucher cannot be used for this ticket."
+
     voucher.quota -= 1
     db.flush()
 
     return voucher, None
+
+
+def get_tickets_by_ids(db: Session, ticket_ids: list[str]) -> list[Ticket]:
+    unique_ticket_ids = list(dict.fromkeys(ticket_ids))
+    if not unique_ticket_ids:
+        return []
+
+    tickets = db.scalars(select(Ticket).where(Ticket.id.in_(unique_ticket_ids))).all()
+    if len(tickets) != len(unique_ticket_ids):
+        raise ValueError("One or more tickets not found")
+    return tickets
+
+
+def voucher_can_be_used_for_ticket(voucher: Voucher, ticket_id: str | None) -> bool:
+    return (
+        ticket_id is None
+        or not voucher.tickets
+        or any(str(ticket.id) == str(ticket_id) for ticket in voucher.tickets)
+    )

--- a/routes/payment.py
+++ b/routes/payment.py
@@ -119,6 +119,7 @@ async def close_unpaid_payments_with_mayar(
 )
 async def validate_voucher(
     code: str,
+    ticket_id: Optional[str] = None,
     db: Session = Depends(get_db_sync),
     token: str = Depends(oauth2_scheme),
 ):
@@ -161,6 +162,13 @@ async def validate_voucher(
                 return common_response(
                     BadRequest(message="You are not authorized to use this voucher.")
                 )
+
+        if not voucherRepo.voucher_can_be_used_for_ticket(
+            voucher=voucher, ticket_id=ticket_id
+        ):
+            return common_response(
+                BadRequest(message="Voucher cannot be used for this ticket.")
+            )
 
         return common_response(
             Ok(
@@ -236,7 +244,10 @@ async def create_payment(
         voucher_participant_type = None
         if request.voucher_code:
             voucher, error_msg = voucherRepo.validate_and_use_voucher(
-                db=db, code=request.voucher_code, user_email=user.email
+                db=db,
+                code=request.voucher_code,
+                user_email=user.email,
+                ticket_id=request.ticket_id,
             )
             if error_msg or voucher is None:
                 db.rollback()

--- a/routes/tests/test_payment.py
+++ b/routes/tests/test_payment.py
@@ -13,6 +13,7 @@ from models.Ticket import Ticket
 from models.Payment import PaymentStatus
 from models.Token import Token
 from models.Voucher import Voucher
+from models.VoucherTicket import VoucherTicket
 from core.security import generate_hash_password
 from repository import payment as paymentRepo
 from main import app
@@ -218,6 +219,80 @@ class TestPayment(IsolatedAsyncioTestCase):
         self.assertEqual(response.status_code, 400)
         data = response.json()
         self.assertEqual(data["message"], "Ticket not found.")
+
+    async def test_voucher_ticket_restrictions_are_enforced(self):
+        unavailable_ticket = Ticket(
+            name="Unavailable for Voucher",
+            price=250000,
+            user_participant_type="In Person",
+            is_active=True,
+        )
+        restricted_voucher = Voucher(
+            code="STUDENTONLY",
+            value=100000,
+            quota=2,
+            is_active=True,
+        )
+        unrestricted_voucher = Voucher(
+            code="ALLTICKETS",
+            value=100000,
+            quota=2,
+            is_active=True,
+        )
+        self.db.add_all([unavailable_ticket, restricted_voucher, unrestricted_voucher])
+        self.db.commit()
+        self.db.add(
+            VoucherTicket(
+                voucher_id=restricted_voucher.id,
+                ticket_id=self.test_ticket.id,
+            )
+        )
+        self.db.commit()
+
+        headers = {"Authorization": f"Bearer {self.test_token}"}
+        rejected_validation = self.client.get(
+            "/payment/voucher/validate",
+            params={
+                "code": "STUDENTONLY",
+                "ticket_id": str(unavailable_ticket.id),
+            },
+            headers=headers,
+        )
+        self.assertEqual(rejected_validation.status_code, 400)
+        self.assertEqual(
+            rejected_validation.json()["message"],
+            "Voucher cannot be used for this ticket.",
+        )
+
+        accepted_validation = self.client.get(
+            "/payment/voucher/validate",
+            params={"code": "STUDENTONLY", "ticket_id": str(self.test_ticket.id)},
+            headers=headers,
+        )
+        self.assertEqual(accepted_validation.status_code, 200)
+
+        rejected_payment = self.client.post(
+            "/payment/",
+            json={
+                "ticket_id": str(unavailable_ticket.id),
+                "voucher_code": "STUDENTONLY",
+            },
+            headers=headers,
+        )
+        self.assertEqual(rejected_payment.status_code, 400)
+        self.assertEqual(
+            rejected_payment.json()["message"],
+            "Voucher cannot be used for this ticket.",
+        )
+        self.db.refresh(restricted_voucher)
+        self.assertEqual(restricted_voucher.quota, 2)
+
+        unrestricted_validation = self.client.get(
+            "/payment/voucher/validate",
+            params={"code": "ALLTICKETS", "ticket_id": str(unavailable_ticket.id)},
+            headers=headers,
+        )
+        self.assertEqual(unrestricted_validation.status_code, 200)
 
     async def test_create_payment_ticket_sold_out(self):
         sold_out_ticket = Ticket(

--- a/routes/tests/test_voucher.py
+++ b/routes/tests/test_voucher.py
@@ -2,6 +2,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy import select
 from core.security import generate_token_from_user
 from models import engine, db, get_db_sync, get_db_sync_for_test
+from models.Ticket import Ticket
 from models.User import MANAGEMENT_PARTICIPANT, User
 from models.Voucher import Voucher
 from main import app
@@ -70,6 +71,76 @@ class TestVoucher(IsolatedAsyncioTestCase):
         assert data["quota"] == 50
         assert data["type"] == "Speaker"
         assert data["is_active"] is False
+
+    async def test_create_and_update_voucher_ticket_restrictions(self):
+        ticket_one = Ticket(
+            name="Student Plan",
+            price=100000,
+            user_participant_type="In Person Participant",
+        )
+        ticket_two = Ticket(
+            name="Regular Plan",
+            price=200000,
+            user_participant_type="In Person Participant",
+        )
+        self.session.add_all([ticket_one, ticket_two])
+        self.session.commit()
+
+        token, _ = await generate_token_from_user(db=self.session, user=self.user)
+        response = self.client.post(
+            "/voucher/",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "code": "STUDENTONLY",
+                "quota": 10,
+                "ticket_ids": [str(ticket_one.id)],
+            },
+        )
+
+        assert response.status_code == 200
+        voucher_id = response.json()["id"]
+
+        detail_response = self.client.get(
+            f"/voucher/{voucher_id}",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert detail_response.status_code == 200
+        assert detail_response.json()["tickets"] == [
+            {"id": str(ticket_one.id), "name": "Student Plan"}
+        ]
+
+        update_response = self.client.put(
+            f"/voucher/{voucher_id}",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "code": "STUDENTONLY",
+                "quota": 10,
+                "ticket_ids": [str(ticket_two.id)],
+            },
+        )
+        assert update_response.status_code == 200
+        updated_detail_response = self.client.get(
+            f"/voucher/{voucher_id}",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert updated_detail_response.json()["tickets"] == [
+            {"id": str(ticket_two.id), "name": "Regular Plan"}
+        ]
+
+    async def test_create_voucher_with_unknown_ticket_is_rejected(self):
+        token, _ = await generate_token_from_user(db=self.session, user=self.user)
+        response = self.client.post(
+            "/voucher/",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "code": "UNKNOWN-TICKET",
+                "quota": 10,
+                "ticket_ids": [str(uuid.uuid4())],
+            },
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "One or more tickets not found"
 
     async def test_create_voucher_with_invalid_participant_type(self):
         """Test that creating voucher with invalid participant type is rejected"""

--- a/routes/voucher.py
+++ b/routes/voucher.py
@@ -26,6 +26,7 @@ from schemas.voucher import (
     VoucherResponse,
     VoucherQuery,
     VoucherListResponse,
+    VoucherTicketResponse,
 )
 
 router = APIRouter(prefix="/voucher", tags=["Voucher"])
@@ -80,6 +81,7 @@ def create_voucher(
             type=request.type,
             email_whitelist=request.email_whitelist,
             is_active=request.is_active,
+            ticket_ids=request.ticket_ids,
         )
         return VoucherResponse(
             id=str(voucher.id),
@@ -90,6 +92,8 @@ def create_voucher(
             quota=voucher.quota,
             is_active=voucher.is_active,
         )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
         import traceback
 
@@ -121,6 +125,10 @@ def get_voucher(
         email_whitelist=voucher.email_whitelist,
         quota=voucher.quota,
         is_active=voucher.is_active,
+        tickets=[
+            VoucherTicketResponse(id=str(ticket.id), name=ticket.name)
+            for ticket in voucher.tickets
+        ],
     )
 
 
@@ -141,16 +149,20 @@ def update_voucher_whole(
     if voucher is None:
         raise HTTPException(status_code=404, detail="Voucher not found")
 
-    voucher = update_voucher(
-        db=db,
-        voucher=voucher,
-        code=request.code,
-        value=request.value,
-        quota=request.quota,
-        type=request.type,
-        email_whitelist=request.email_whitelist,
-        is_active=request.is_active,
-    )
+    try:
+        voucher = update_voucher(
+            db=db,
+            voucher=voucher,
+            code=request.code,
+            value=request.value,
+            quota=request.quota,
+            type=request.type,
+            email_whitelist=request.email_whitelist,
+            is_active=request.is_active,
+            ticket_ids=request.ticket_ids,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
 
     return VoucherResponse(
         id=str(voucher.id),
@@ -160,6 +172,10 @@ def update_voucher_whole(
         email_whitelist=voucher.email_whitelist,
         quota=voucher.quota,
         is_active=voucher.is_active,
+        tickets=[
+            VoucherTicketResponse(id=str(ticket.id), name=ticket.name)
+            for ticket in voucher.tickets
+        ],
     )
 
 

--- a/schemas/voucher.py
+++ b/schemas/voucher.py
@@ -1,6 +1,6 @@
 from typing import List, Optional, TypedDict
 from fastapi import Query
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from uuid import UUID
 from schemas.user_profile import ParticipantType
 
@@ -23,6 +23,7 @@ class VoucherCreateRequest(BaseModel):
     type: ParticipantType | None = None
     email_whitelist: EmailWhiteListDict | None = None
     is_active: bool = False
+    ticket_ids: List[UUID] = Field(default_factory=list)
 
 
 class VoucherUpdateRequest(BaseModel):
@@ -32,6 +33,7 @@ class VoucherUpdateRequest(BaseModel):
     type: ParticipantType | None = None
     email_whitelist: EmailWhiteListDict | None = None
     is_active: bool = False
+    ticket_ids: List[UUID] = Field(default_factory=list)
 
 
 class VoucherUpdateStatusRequest(BaseModel):
@@ -54,6 +56,13 @@ class VoucherUpdateTypeRequest(BaseModel):
     type: ParticipantType
 
 
+class VoucherTicketResponse(BaseModel):
+    id: str
+    name: str
+
+    model_config = {"from_attributes": True}
+
+
 class VoucherResponse(BaseModel):
     id: str
     code: str
@@ -62,6 +71,7 @@ class VoucherResponse(BaseModel):
     email_whitelist: EmailWhiteListDict | None = None
     quota: int
     is_active: bool
+    tickets: List[VoucherTicketResponse] = Field(default_factory=list)
 
 
 class VoucherResponseItem(BaseModel):


### PR DESCRIPTION
## Summary
Pada issue pyconid/pyconid-be#180 ada keperluan untuk menambahkan pembatasan penggunaan voucher berdasarkan ticket yang dipilih saat pembayaran.

## Changes
- Menambahkan relasi many-to-many antara voucher dan ticket melalui tabel `voucher_ticket` beserta migrasinya.
- Menambahkan dukungan `ticket_ids` pada pembuatan dan pembaruan voucher, termasuk validasi ticket yang tidak ditemukan.
- Menampilkan daftar ticket yang terkait pada respons voucher.
- Memvalidasi kecocokan voucher dengan `ticket_id` saat validasi voucher dan pembuatan pembayaran.
- Menolak penggunaan voucher untuk ticket yang tidak diizinkan tanpa mengurangi kuota voucher.
- Menambahkan test untuk pembatasan ticket, perubahan ticket voucher, serta penolakan ticket yang tidak valid.

## Validation
- Voucher hanya dapat digunakan untuk ticket yang telah dikaitkan.
- Kuota voucher tetap utuh ketika voucher ditolak karena ticket tidak sesuai.
- Ticket voucher dapat diganti melalui endpoint update.
- `ticket_ids` yang tidak valid menghasilkan `400 Bad Request`.

Closes #180 