### PR TITLE
feat(organizer): Enhance public organizer details and add privacy tests

### DIFF
--- a/routes/organizer.py
+++ b/routes/organizer.py
@@ -37,8 +37,10 @@ from schemas.organizer import (
     organizer_detail_response_from_model,
     organizer_response_item_from_model,
     organizer_detail_response_list_from_models,
+    organizer_public_detail_response_list_from_models,
     OrganizerQuery,
     OrganizerDetailResponseList,
+    PublicOrganizerDetailResponseList,
     OrganizersByTypeAll,
     OrganizersByType,
     OrganizerResponseItem,
@@ -93,7 +95,7 @@ def get_organizers_grouped_by_type(
 @router.get(
     "/public",
     responses={
-        "200": {"model": OrganizerDetailResponseList},
+        "200": {"model": PublicOrganizerDetailResponseList},
         "404": {"model": NotFoundResponse},
         "500": {"model": InternalServerErrorResponse},
     },
@@ -108,7 +110,7 @@ def get_organizers_public(
         if data is None:
             return common_response(NotFound(message="No organizers found"))
 
-        model_data = organizer_detail_response_list_from_models(data)
+        model_data = organizer_public_detail_response_list_from_models(data)
         return common_response(Ok(data=model_data.model_dump()))
     except Exception as e:
         logger.error(f"Error fetching organizers by type: {e}")

--- a/routes/tests/test_organizer.py
+++ b/routes/tests/test_organizer.py
@@ -29,6 +29,64 @@ class TestOrganizer(IsolatedAsyncioTestCase):
         # "create_savepoint" join_transaction_mode
         self.db = db(bind=self.connection, join_transaction_mode="create_savepoint")
 
+    async def test_get_organizers_public_job_fields_respect_privacy(self):
+        # Given
+        organizer_type = OrganizerType(name="Core Team")
+        self.db.add(organizer_type)
+
+        shared_user = User(
+            username="shared-organizer",
+            company="PyCon Indonesia",
+            job_category="Technology",
+            job_title="Software Engineer",
+            share_my_job_and_company=True,
+        )
+        hidden_user = User(
+            username="hidden-organizer",
+            company="Private Company",
+            job_category="Finance",
+            job_title="Accountant",
+            share_my_job_and_company=False,
+        )
+        unset_user = User(
+            username="unset-organizer",
+            company="Undisclosed Company",
+            job_category="Operations",
+            job_title="Coordinator",
+            share_my_job_and_company=None,
+        )
+        shared_organizer = Organizer(user=shared_user, organizer_type=organizer_type)
+        hidden_organizer = Organizer(user=hidden_user, organizer_type=organizer_type)
+        unset_organizer = Organizer(user=unset_user, organizer_type=organizer_type)
+        self.db.add_all([shared_organizer, hidden_organizer, unset_organizer])
+        self.db.commit()
+
+        app.dependency_overrides[get_db_sync] = get_db_sync_for_test(db=self.db)
+        client = TestClient(app)
+
+        # When
+        response = client.get("/organizer/public")
+
+        # Expect
+        self.assertEqual(response.status_code, 200)
+        organizers = {item["id"]: item for item in response.json()["results"]}
+
+        shared_response = organizers[str(shared_organizer.id)]["user"]
+        self.assertEqual(shared_response["company"], "PyCon Indonesia")
+        self.assertEqual(shared_response["job_category"], "Technology")
+        self.assertEqual(shared_response["job_title"], "Software Engineer")
+        self.assertNotIn("share_my_job_and_company", shared_response)
+        self.assertIn("organizer_type", organizers[str(shared_organizer.id)])
+
+        for organizer in (hidden_organizer, unset_organizer):
+            organizer_user = organizers[str(organizer.id)]["user"]
+            self.assertIn("company", organizer_user)
+            self.assertIn("job_category", organizer_user)
+            self.assertIn("job_title", organizer_user)
+            self.assertIsNone(organizer_user["company"])
+            self.assertIsNone(organizer_user["job_category"])
+            self.assertIsNone(organizer_user["job_title"])
+
     async def test_get_all_organizers(self):
         # Given
         user_management = User(

--- a/schemas/organizer.py
+++ b/schemas/organizer.py
@@ -29,6 +29,12 @@ class OrganizerDetailUser(BaseModel):
     twitter_username: str | None = None
 
 
+class PublicOrganizerDetailUser(OrganizerDetailUser):
+    company: str | None = None
+    job_category: str | None = None
+    job_title: str | None = None
+
+
 class OrganizerDetailType(BaseModel):
     id: str
     name: str
@@ -42,6 +48,16 @@ class OrganizerDetailResponse(BaseModel):
 
 class OrganizerDetailResponseList(BaseModel):
     results: list[OrganizerDetailResponse]
+
+
+class PublicOrganizerDetailResponse(BaseModel):
+    id: str
+    user: PublicOrganizerDetailUser
+    organizer_type: OrganizerDetailType
+
+
+class PublicOrganizerDetailResponseList(BaseModel):
+    results: list[PublicOrganizerDetailResponse]
 
 
 class OrganizerCreateRequest(BaseModel):
@@ -110,6 +126,21 @@ def organizer_detail_user_from_model(organizer: Organizer) -> OrganizerDetailUse
     )
 
 
+def organizer_public_detail_user_from_model(
+    organizer: Organizer,
+) -> PublicOrganizerDetailUser:
+    """Convert Organizer ORM model to PublicOrganizerDetailUser Pydantic model."""
+    user: User = organizer.user
+    organizer_user = organizer_detail_user_from_model(organizer)
+
+    return PublicOrganizerDetailUser(
+        **organizer_user.model_dump(),
+        company=user.company if user.share_my_job_and_company else None,
+        job_category=user.job_category if user.share_my_job_and_company else None,
+        job_title=user.job_title if user.share_my_job_and_company else None,
+    )
+
+
 def organizer_detail_response_from_model(
     organizer: Organizer,
 ) -> OrganizerDetailResponse:
@@ -125,12 +156,38 @@ def organizer_detail_response_from_model(
     )
 
 
+def organizer_public_detail_response_from_model(
+    organizer: Organizer,
+) -> PublicOrganizerDetailResponse:
+    """Convert Organizer ORM model to PublicOrganizerDetailResponse Pydantic model."""
+    organizer_type = organizer.organizer_type
+    return PublicOrganizerDetailResponse(
+        id=str(organizer.id),
+        user=organizer_public_detail_user_from_model(organizer),
+        organizer_type=OrganizerDetailType(
+            id=str(organizer_type.id),
+            name=organizer_type.name,
+        ),
+    )
+
+
 def organizer_detail_response_list_from_models(
     organizers: Sequence[Organizer],
 ) -> OrganizerDetailResponseList:
     """Convert list of Organizer ORM models to OrganizerDetailResponseList Pydantic model."""
     return OrganizerDetailResponseList(
         results=[organizer_detail_response_from_model(org) for org in organizers],
+    )
+
+
+def organizer_public_detail_response_list_from_models(
+    organizers: Sequence[Organizer],
+) -> PublicOrganizerDetailResponseList:
+    """Convert organizer models to PublicOrganizerDetailResponseList Pydantic model."""
+    return PublicOrganizerDetailResponseList(
+        results=[
+            organizer_public_detail_response_from_model(org) for org in organizers
+        ],
     )
 
 


### PR DESCRIPTION
## Summary

Closes #184

Add `company`, `job_category`, and `job_title` to `GET /organizer/public` responses, aligned with the privacy behavior of `GET /speaker/public`.

## Changes

- Add public-only organizer response schemas and mappers.
- Return `company`, `job_category`, and `job_title` under `results[].user`.
- Protect job and company data using `share_my_job_and_company`:
  - `true`: return the stored values.
  - `false` or `null`: return the fields as `null`.
- Keep authenticated organizer endpoint response contracts unchanged.
- Add endpoint coverage for opted-in, opted-out, and unset privacy flags.

## Verification

- [x] `ruff check --exit-non-zero-on-fix`
- [x] `ruff format --check`
- [x] `git diff --check`
- [x] In-memory privacy mapper validation for `true`, `false`, and `null` consent states.
- [x] PostgreSQL-backed endpoint tests: `12 passed` in `routes/tests/test_organizer.py`.

## API Example

```json
{
  "results": [
    {
      "id": "organizer-id",
      "user": {
        "id": "user-id",
        "first_name": "Jane",
        "last_name": "Doe",
        "company": "PyCon Indonesia",
        "job_category": "Technology",
        "job_title": "Software Engineer"
      },
      "organizer_type": {
        "id": "organizer-type-id",
        "name": "Core Team"
      }
    }
  ]
}
```
